### PR TITLE
Fix highlighting of floating-point F-codes

### DIFF
--- a/syntaxes/gcode.tmLanguage
+++ b/syntaxes/gcode.tmLanguage
@@ -42,7 +42,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>[F]([ \t]*[\d])*[ \t]*</string>
+			<string>[F](\+?[\d]*\-?[\d]*\.?[\d]*)</string>
 			<key>name</key>
 			<string>constant.numeric.fcode.gcode</string>
 		</dict>


### PR DESCRIPTION
F-codes can also contain a decimal point.
<img width="276" alt="before" src="https://user-images.githubusercontent.com/1623257/44633603-e5760500-a98d-11e8-8f46-97466f2e00c5.png">
<img width="284" alt="after" src="https://user-images.githubusercontent.com/1623257/44633604-e5760500-a98d-11e8-91f6-007dfce326f9.png">


