### PR TITLE
Fixed highligting of T codes

### DIFF
--- a/syntaxes/gcode.tmLanguage
+++ b/syntaxes/gcode.tmLanguage
@@ -36,6 +36,12 @@
 		</dict>
 		<dict>
 			<key>match</key>
+			<string>[T]([\d]+\s)</string>
+			<key>name</key>
+			<string>constant.numeric.tcode.gcode</string>
+		</dict>
+		<dict>
+			<key>match</key>
 			<string>[E](\+?[\d]*\-?[\d]*\.?[\d]*)</string>
 			<key>name</key>
 			<string>constant.numeric.ecode.gcode</string>


### PR DESCRIPTION
Note that I added support only for integer values.

![image](https://user-images.githubusercontent.com/55032128/109397895-56754980-794a-11eb-889e-c499b59156b3.png)